### PR TITLE
Dynamic app name in label

### DIFF
--- a/charms/kubernetes-dashboard/src/charm.py
+++ b/charms/kubernetes-dashboard/src/charm.py
@@ -198,7 +198,7 @@ class K8sDashboardCharm(CharmBase):
                     'name': 'kubernetes-dashboard',
                     'spec': {
                         'selector': {
-                            'juju-app': 'kubernetes-dashboard',
+                            'juju-app': self.model.app.name,
                         },
                         'ports': [{
                             'protocol': 'TCP',

--- a/docs/local-overlay.yaml
+++ b/docs/local-overlay.yaml
@@ -10,7 +10,7 @@ description: |
       `juju deploy ./docs/local-overlay.yaml`
 bundle: kubernetes
 applications:
-  kubernetes-dashboard:
+  k8s-dashboard:
     charm: ../kubernetes-dashboard.charm
     scale: 1
     resources:
@@ -21,4 +21,4 @@ applications:
     resources:
       metrics-scraper-image: 'kubernetesui/metrics-scraper:v1.0.5'
 relations:
-  - [dashboard-metrics-scraper, kubernetes-dashboard]
+  - [dashboard-metrics-scraper, k8s-dashboard]


### PR DESCRIPTION
Fix hard coded juju application name and rename
dashboard charm to k8s-dashboard due to juju bug:

https://bugs.launchpad.net/juju/+bug/1903683

Signed-off-by: Dominik Fleischmann <dominik.fleischmann@canonical.com>